### PR TITLE
feat: adds metrics statsd with interface

### DIFF
--- a/observe/lib/metrics.py
+++ b/observe/lib/metrics.py
@@ -1,0 +1,47 @@
+"""This module defines an example of a custom IMetric implementation.
+"""
+from typing import List, Optional, Text
+
+from datadog import DogStatsd
+
+
+class IMetric:
+    """This interface defines methods the @observe decorator is going to call, it is a sub-set of DogStatsd.
+    """
+
+    def timing(
+            self,
+            metric: Text,
+            value: float,
+            tags: Optional[List[str]] = None,
+            sample_rate: Optional[float] = None):
+        """Record the timing value for the metric, appends tags.
+        """
+        raise NotImplementedError("%s: the method is not implemented." % self.__class__.__name__)
+
+    def increment(
+            self,
+            metric: Text,
+            value: float = 1,
+            tags: Optional[List[str]] = None,
+            sample_rate: Optional[float] = None):
+        """Increment the metric by the provided value, appends tags.
+        """
+        raise NotImplementedError("%s: the method is not implemented." % self.__class__.__name__)
+
+
+class Metric(DogStatsd, IMetric):
+    """This is an example of a custom IMetric implementation, using the actual DogStatsd client which @observers would
+    support natively.
+
+    Note: we do not need to overwrite the timing, increment methods since the interfaces match 100%.
+
+    Args:
+        DogStatsd (class): this is the class as provided by the datadog package (from datadog import DogStatsd)
+        IMetric (interface): this is the interface class provided by @observe for users who don't want to use DogStatsd
+    """
+
+    def __init__(self, **kwargs):
+        """Initializes the Metric client.
+        """
+        super(Metric, self).__init__(**kwargs)

--- a/observe/lib/slack.py
+++ b/observe/lib/slack.py
@@ -23,8 +23,12 @@ class Slack:
 
     def __init__(self, web_hook: str = None) -> None:
         """Initializes the Slack client.
+
         Args:
             web_hook (str, optional): the slack web hook to be used for notifications. Defaults to None.
+
+        Raises:
+            MissingSlackWebhookException
         """
         self.web_hook = web_hook or os.environ.get("SLACK_WEB_HOOK", None)
         if not self.web_hook:

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pylint
 mock
 
 requests
+datadog

--- a/test/unit/test_metric.py
+++ b/test/unit/test_metric.py
@@ -1,0 +1,74 @@
+"""Defines tests for metric.Metric class
+"""
+from unittest import TestCase
+
+from datadog import DogStatsd
+from mock import patch
+
+from observe.lib.metrics import IMetric, Metric
+
+
+class TestMetricInitialization(TestCase):
+    """Defines tests for the Metric.__init__ method, mainly interested that we did not break statsd.
+    """
+
+    def setUp(self) -> None:
+        self.env_dd = patch.dict('os.environ', {
+            'DD_AGENT_HOST': 'env_host',
+            'DD_DOGSTATSD_PORT': '4321',
+            'DATADOG_TAGS': 'my_tag_1,my_tag_2'
+        })
+
+    def test_successful_default(self):
+        # arrange, act
+        client = Metric()
+        # assert interface
+        self.assertIsInstance(client, DogStatsd)
+        self.assertIsInstance(client, IMetric)
+        # assert statsd
+        self.assertEqual(client.host, "localhost")
+        self.assertEqual(client.port, 8125)
+
+    def test_successful_kwargs(self):
+        # arrange, act
+        client = Metric(**{
+            "host": "myhost",
+            "port": 1234
+        })
+        # assert interface
+        self.assertIsInstance(client, DogStatsd)
+        self.assertIsInstance(client, IMetric)
+        # assert statsd
+        self.assertEqual(client.host, "myhost")
+        self.assertEqual(client.port, 1234)
+
+    def test_successful_env(self):
+        # arrange env
+        with self.env_dd:
+            # act
+            client = Metric()
+
+        # assert interface
+        self.assertIsInstance(client, DogStatsd)
+        self.assertIsInstance(client, IMetric)
+        # assert statsd
+        self.assertEqual(client.host, "env_host")
+        self.assertEqual(client.port, 4321)
+        self.assertEqual(client.constant_tags, ["my_tag_1", "my_tag_2"])
+
+    def test_successful_overwrite(self):
+        # arrange, act
+        client = Metric()
+        # act overwrite
+        client.namespace = "observe"
+        client.constant_tags.append("observe")
+        client.host = "micros_host"
+        client.port = 1337
+        # assert interface
+        self.assertIsInstance(client, DogStatsd)
+        self.assertIsInstance(client, IMetric)
+        # assert statsd
+        self.assertEqual(client.host, "micros_host")
+        self.assertEqual(client.port, 1337)
+        self.assertEqual(client.constant_tags, ["observe"])
+        self.assertEqual(client.namespace, "observe")


### PR DESCRIPTION
### class IMetric
* The intention is to give the user the ability to define their own metrics client
* @observe will search on `isinstance(arg, IMetric)` in order to resolve the metric client

### class Metric(DogStatsd, IMetric)
* Even tho we can just use DogStatsd, this is an example of how you could utilize the IMetric interface 